### PR TITLE
fix: added capacitor values for tuning

### DIFF
--- a/docs/bill-of-materials.csv
+++ b/docs/bill-of-materials.csv
@@ -1,6 +1,8 @@
 "Reference","Value","Datasheet","Footprint","Qty","DNP","Description"
 "C1,C2,C3,C4,C5,C6,C8,C9,C11","1uF","~","-- mixed values --","9","","Unpolarized capacitor, small symbol"
 "C7,C10,C14,C25,C26,C28","104","~","Capacitor_SMD:C_0402_1005Metric","6","","Unpolarized capacitor, small symbol"
+"C27","100pF","~","Capacitor_SMD:C_0402_1005Metric","1","","Unpolarized capacitor, small symbol"
+"C29","56pF","~","Capacitor_SMD:C_0402_1005Metric","1","","Unpolarized capacitor, small symbol"
 "C12,C13","10uF","~","Capacitor_SMD:C_0603_1608Metric","2","","Unpolarized capacitor, small symbol"
 "C15,C16,C17,C18,C19,C20,C21,C22,C23,C24","100uF","~","Capacitor_SMD:C_1206_3216Metric","10","","Unpolarized capacitor, small symbol"
 "D1,D2,D3","1N5819W","~","Diode_SMD:D_SOD-123","3","","V.rrm > 20V, I.f > 500mA"

--- a/magic-epaper.kicad_sch
+++ b/magic-epaper.kicad_sch
@@ -7350,8 +7350,8 @@
 				)
 			)
 		)
-		(property "Value" "Cx"
-			(at 214.376 38.1 90)
+		(property "Value" "56pF"
+			(at 213.36 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9895,8 +9895,8 @@
 				)
 			)
 		)
-		(property "Value" "Cx"
-			(at 206.756 38.1 90)
+		(property "Value" "DNP"
+			(at 205.74 37.592 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10095,8 +10095,8 @@
 				)
 			)
 		)
-		(property "Value" "Cx"
-			(at 200.406 38.1 90)
+		(property "Value" "DNP"
+			(at 199.39 37.592 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12263,8 +12263,8 @@
 				)
 			)
 		)
-		(property "Value" "Cx"
-			(at 220.726 38.1 90)
+		(property "Value" "100pF"
+			(at 219.71 36.83 90)
 			(effects
 				(font
 					(size 1.27 1.27)


### PR DESCRIPTION
Antenna port requires about 150-160 pF capacitance to bring down the operating frequency from around 40+ MHz to 13.56 MHz (ISO/IEC 15693).

## Summary by Sourcery

Add tuning capacitors to the antenna circuit and update documentation to correct the operating frequency for ISO/IEC 15693 compliance

Bug Fixes:
- Add approximately 150–160 pF capacitors to the antenna port to bring the operating frequency down to 13.56 MHz

Enhancements:
- Update KiCad schematic to include the new antenna tuning capacitors

Documentation:
- Add capacitor entries to docs/bill-of-materials.csv for antenna tuning